### PR TITLE
feat: AutoChannel and duplicate filtering for AutoCache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ bin/
 obj/
 .generated/
 .vs/
+.idea/
 .DS_Store
 *.DotSettings.user
 *.binlog

--- a/Chickensoft.Sync.Tests/src/SyncSubjectTest.cs
+++ b/Chickensoft.Sync.Tests/src/SyncSubjectTest.cs
@@ -26,7 +26,7 @@ public sealed class SyncSubjectTest
     public readonly record struct TestOp2;
     public SyncSubject Subject { get; set; } = default!;
 
-    public Action<SyncSubject, object> Action { get; set; }
+    public required Action<SyncSubject, object> Action { get; set; }
     public required Action<SyncSubject, TestOp1> TestAction1 { get; init; }
     public required Action<SyncSubject, TestOp2> TestAction2 { get; init; }
 
@@ -256,6 +256,12 @@ public sealed class SyncSubjectTest
     var log = new List<string>();
     var owner = new TestOwnerAny
     {
+      Action = (subj, value) =>
+      {
+        log.Add($"{nameof(TestOwnerAny.Action)} {value}");
+        if (value is int number)
+          subj.Broadcast(number);
+      },
       TestAction1 = (subj, value) =>
       {
         log.Add($"{nameof(TestOwnerAny.TestAction1)} {value}");
@@ -266,13 +272,6 @@ public sealed class SyncSubjectTest
         log.Add($"{nameof(TestOwnerAny.TestAction2)} {value}");
         subj.Broadcast(value);
       }
-    };
-
-    owner.Action = (subj, value) =>
-    {
-      log.Add($"{nameof(TestOwnerAny.Action)} {value}");
-      if (value is int number)
-        subj.Broadcast(number);
     };
 
     var subject = new SyncSubject(owner);

--- a/Chickensoft.Sync.Tests/src/SyncSubjectTest.cs
+++ b/Chickensoft.Sync.Tests/src/SyncSubjectTest.cs
@@ -17,6 +17,24 @@ public sealed class SyncSubjectTest
     public void Perform(in T op) => Action(Subject, op);
   }
 
+  public sealed class TestOwnerAny :
+    IPerformAnyOperation,
+    IPerform<TestOwnerAny.TestOp1>,
+    IPerform<TestOwnerAny.TestOp2>
+  {
+    public readonly record struct TestOp1;
+    public readonly record struct TestOp2;
+    public SyncSubject Subject { get; set; } = default!;
+
+    public Action<SyncSubject, object> Action { get; set; }
+    public required Action<SyncSubject, TestOp1> TestAction1 { get; init; }
+    public required Action<SyncSubject, TestOp2> TestAction2 { get; init; }
+
+    public void Perform<TOp>(in TOp op) where TOp : struct => Action(Subject, op);
+    public void Perform(in TestOp1 op) => TestAction1(Subject, op);
+    public void Perform(in TestOp2 op) => TestAction2(Subject, op);
+  }
+
   public TestOwner<int> Nop => new()
   {
     Action = (_, __) => { }
@@ -230,6 +248,78 @@ public sealed class SyncSubjectTest
 
     // owner should run before bindings each time
     log.ShouldBe(["owner 1", "callback 1", "owner 2", "callback 2"]);
+  }
+
+  [Fact]
+  public void PerformsAnyOpsSerialized()
+  {
+    var log = new List<string>();
+    var owner = new TestOwnerAny
+    {
+      TestAction1 = (subj, value) =>
+      {
+        log.Add($"{nameof(TestOwnerAny.TestAction1)} {value}");
+        subj.Broadcast(value);
+      },
+      TestAction2 = (subj, value) =>
+      {
+        log.Add($"{nameof(TestOwnerAny.TestAction2)} {value}");
+        subj.Broadcast(value);
+      }
+    };
+
+    owner.Action = (subj, value) =>
+    {
+      log.Add($"{nameof(TestOwnerAny.Action)} {value}");
+      if (value is int number)
+        subj.Broadcast(number);
+    };
+
+    var subject = new SyncSubject(owner);
+    owner.Subject = subject;
+
+    var binding1 = new Mock<ISyncBinding>();
+    var binding2 = new Mock<ISyncBinding>();
+
+    var calls = 0;
+
+    binding1.Setup(b => b.InvokeCallbacks(It.Ref<TestOwnerAny.TestOp1>.IsAny))
+      .Callback((in TestOwnerAny.TestOp1 value) =>
+      {
+        log.Add($"callback {value}");
+        calls++;
+
+        subject.IsBusy.ShouldBeTrue();
+
+        if (calls == 1)
+        {
+          subject.Perform(new TestOwnerAny.TestOp2());
+          // this should not be broadcast yet
+          binding2.Verify(
+            b2 => b2.InvokeCallbacks(It.Ref<TestOwnerAny.TestOp2>.IsAny), Times.Never
+          );
+        }
+      });
+
+    subject.AddBinding(binding1.Object);
+    subject.AddBinding(binding2.Object);
+    subject.Perform(new TestOwnerAny.TestOp1());
+    subject.Perform(2);
+    subject.IsBusy.ShouldBeFalse();
+
+    binding2.Verify(b2 => b2.InvokeCallbacks(It.Ref<TestOwnerAny.TestOp1>.IsAny));
+    binding2.Verify(b2 => b2.InvokeCallbacks(It.Ref<TestOwnerAny.TestOp2>.IsAny));
+    binding2.Verify(b2 => b2.InvokeCallbacks(2));
+
+    // owner should run before bindings each time
+    log.ShouldBe([
+      $"{nameof(TestOwnerAny.TestAction1)} {nameof(TestOwnerAny.TestOp1)} {{ }}",
+      $"callback {nameof(TestOwnerAny.TestOp1)} {{ }}",
+      $"{nameof(TestOwnerAny.Action)} {nameof(TestOwnerAny.TestOp1)} {{ }}",
+      $"{nameof(TestOwnerAny.TestAction2)} {nameof(TestOwnerAny.TestOp2)} {{ }}",
+      $"{nameof(TestOwnerAny.Action)} {nameof(TestOwnerAny.TestOp2)} {{ }}",
+      $"{nameof(TestOwnerAny.Action)} 2"
+    ]);
   }
 
   [Fact]

--- a/Chickensoft.Sync.Tests/src/primitives/AutoChannelTest.cs
+++ b/Chickensoft.Sync.Tests/src/primitives/AutoChannelTest.cs
@@ -1,0 +1,187 @@
+namespace Chickensoft.Sync.Tests.Primitives;
+
+using Shouldly;
+using Sync.Primitives;
+
+public sealed class AutoChannelTest
+{
+  private readonly record struct TestValue(int Value);
+  private readonly record struct TestMessage(string Text);
+
+  [Fact]
+  public void Initializes()
+  {
+    var channel = new AutoChannel();
+    var received = false;
+
+    channel.Bind()
+      .On((in int v) => received = true);
+
+    received.ShouldBeFalse();
+  }
+
+  [Fact]
+  public void NoReentrancy()
+  {
+    var channel = new AutoChannel();
+    var inCallback = false;
+    var reentered = false;
+
+    channel.Bind()
+      .On((in int v) =>
+      {
+        if (inCallback)
+        {
+          reentered = true; // signals immediate (re-entrant) delivery
+        }
+
+        inCallback = true;
+
+        if (v == 1)
+        {
+          channel.Send(2); // attempt re-entrant send
+        }
+
+        inCallback = false;
+      });
+
+    channel.Send(1);
+
+    reentered.ShouldBe(false);
+  }
+
+  [Fact]
+  public void BroadcastsAllSentValues()
+  {
+    var channel = new AutoChannel();
+    var values = new List<int>();
+
+    channel.Bind()
+      .On((in int v) => values.Add(v));
+
+    channel.Send(5);
+    channel.Send(10);
+    channel.Send(10);
+    channel.Send(15);
+
+    values.ShouldBe([5, 10, 10, 15]);
+  }
+
+  [Fact]
+  public void BroadcastsMultipleTypes()
+  {
+    var channel = new AutoChannel();
+    var values = new List<object>();
+
+    channel.Bind()
+      .On((in int v) => values.Add(v))
+      .On((in double v) => values.Add(v))
+      .On((in TestValue v) => values.Add(v))
+      .On((in TestMessage v) => values.Add(v));
+
+    channel.Send(42);
+    channel.Send(3.14);
+    channel.Send(new TestValue(100));
+    channel.Send(new TestMessage("hello"));
+
+    values.ShouldBe([42, 3.14, new TestValue(100), new TestMessage("hello")]);
+  }
+
+
+  [Fact]
+  public void ConditionalCallbacks()
+  {
+    var channel = new AutoChannel();
+    var values = new List<int>();
+    var evenValues = new List<int>();
+
+    channel.Bind()
+      .On((in int v) => values.Add(v))
+      .On(
+        (in int v) => evenValues.Add(v),
+        condition: v => v % 2 == 0
+      );
+
+    channel.Send(1);
+    channel.Send(2);
+    channel.Send(3);
+    channel.Send(4);
+    channel.Send(5);
+
+    values.ShouldBe([1, 2, 3, 4, 5]);
+    evenValues.ShouldBe([2, 4]);
+  }
+
+  [Fact]
+  public void MultipleBindings()
+  {
+    var channel = new AutoChannel();
+    var values1 = new List<int>();
+    var values2 = new List<int>();
+    var values3 = new List<int>();
+
+    channel.Bind()
+      .On((in int v) => values1.Add(v));
+
+    channel.Bind()
+      .On((in int v) => values2.Add(v));
+
+    channel.Bind()
+      .On((in int v) => values3.Add(v));
+
+    channel.Send(7);
+    channel.Send(14);
+
+    values1.ShouldBe([7, 14]);
+    values2.ShouldBe([7, 14]);
+    values3.ShouldBe([7, 14]);
+  }
+
+  [Fact]
+  public void DisposedBindingStopsReceiving()
+  {
+    var channel = new AutoChannel();
+    var values = new List<int>();
+
+    var binding = channel.Bind();
+    binding.On((in int v) => values.Add(v));
+
+    channel.Send(1);
+    values.ShouldBe([1]);
+
+    binding.Dispose();
+
+    channel.Send(2);
+    values.ShouldBe([1]); // Should not receive the second value
+  }
+
+  [Fact]
+  public void ClearsBindings()
+  {
+    var channel = new AutoChannel();
+    var values = new List<int>();
+
+    using var binding = channel.Bind();
+    binding.On((in int v) => values.Add(v));
+
+    channel.Send(1);
+    channel.Send(2);
+
+    values.ShouldBe([1, 2]);
+    values.Clear();
+
+    channel.ClearBindings();
+    channel.Send(3);
+    values.ShouldBeEmpty();
+  }
+
+  [Fact]
+  public void Disposes()
+  {
+    var channel = new AutoChannel();
+
+    channel.Dispose();
+
+    Should.Throw<ObjectDisposedException>(() => channel.Send(2));
+  }
+}

--- a/Chickensoft.Sync/src/SyncSubject.cs
+++ b/Chickensoft.Sync/src/SyncSubject.cs
@@ -92,6 +92,39 @@ public interface IPerform<TOp> where TOp : struct
 
 /// <summary>
 /// <para>
+/// Represents a handler for any type of atomic operation. Reactive
+/// components which own a <see cref="SyncSubject" /> can implement this
+/// method to perform all scheduled operations.
+/// </para>
+/// <para>
+/// To protect against re-entrance, Operations cannot always be performed
+/// right away. <see cref="SyncSubject" /> handles the operations event
+/// loop without boxing operations and defers execution until any pending
+/// operations complete when a new one is added.
+/// </para>
+/// <seealso cref="IPerform{T}"/>
+/// </summary>
+public interface IPerformAnyOperation
+{
+  /// <summary>
+  /// <para>
+  /// Represents a handler for any type of atomic operation. Reactive
+  /// components which own a <see cref="SyncSubject" /> can implement this
+  /// method to perform all scheduled operations.
+  /// </para>
+  /// <para>
+  /// To protect against re-entrance, Operations cannot always be performed
+  /// right away. <see cref="SyncSubject" /> handles the operations event
+  /// loop without boxing operations and defers execution until any pending
+  /// operations complete when a new one is added.
+  /// </para>
+  /// <seealso cref="IPerform{T}.Perform(in T)"/>
+  /// </summary>
+  void Perform<TOp>(in TOp op) where TOp : struct;
+}
+
+/// <summary>
+/// <para>
 /// In ReactiveX (Rx) terminology, this is a "PublishSubject" that is hot
 /// (discards values when there are no listeners), serialized (defers
 /// mutations and invocations while already processing to protect against
@@ -318,6 +351,10 @@ public sealed class SyncSubject : ISyncSubject
     if (_owner is IPerform<TOp> handler)
     {
       handler.Perform(in op);
+    }
+    if (_owner is IPerformAnyOperation handlerAny)
+    {
+      handlerAny.Perform(in op);
     }
   }
 

--- a/Chickensoft.Sync/src/primitives/AutoChannel.cs
+++ b/Chickensoft.Sync/src/primitives/AutoChannel.cs
@@ -92,9 +92,6 @@ public sealed class AutoChannel : IAutoChannel, IPerformAnyOperation
   /// <typeparam name="T">Value Type</typeparam>
   public void Send<T>(in T value) where T : struct => _subject.Perform(value);
 
-  private void Broadcast<T>(in T value) where T : struct =>
-    _subject.Broadcast(value); // invoke callbacks registered for this value
-
   void IPerformAnyOperation.Perform<TMessage>(in TMessage message) where TMessage : struct =>
-    Broadcast(message);
+    _subject.Broadcast(message);
 }

--- a/Chickensoft.Sync/src/primitives/AutoChannel.cs
+++ b/Chickensoft.Sync/src/primitives/AutoChannel.cs
@@ -1,0 +1,116 @@
+namespace Chickensoft.Sync.Primitives;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using Collections;
+using Sync;
+
+/// <summary>
+/// <para>
+/// A channel which broadcasts value types.
+/// </para>
+/// </summary>
+public interface IAutoChannel : IAutoObject<AutoChannel.Binding>;
+
+/// <inheritdoc cref="IAutoChannel"/>
+public sealed class AutoChannel : IAutoChannel, IPerform<AutoChannel.PopOp>
+{
+  // Atomic operations
+  private readonly record struct PopOp;
+
+  /// <summary>
+  /// A binding to an <see cref="AutoChannel"/>.
+  /// </summary>
+  public class Binding : SyncBinding
+  {
+    internal Binding(ISyncSubject subject) : base(subject) { }
+
+    /// <summary>
+    /// Registers a callback that is invoked whenever a value is pushed of a
+    /// specific value type
+    /// </summary>
+    /// <param name="callback">Callback to invoke.</param>
+    /// <param name="condition">Optional condition that must be true for the
+    /// callback to be invoked.</param>
+    /// <typeparam name="T">Value Type to Listen For</typeparam>
+    /// <returns>This binding (for chaining).</returns>
+    [
+      SuppressMessage(
+        "Style",
+        "IDE0350",
+        Justification = "Implicit lambda with ref type won't compile"
+      )
+    ]
+    public Binding On<T>(
+      Callback<T> callback, Func<T, bool>? condition = null) where T : struct
+    {
+      bool predicate(T value) => condition?.Invoke(value) ?? true;
+
+      AddCallback(
+        (in T broadcast) => callback(broadcast),
+        (in T broadcast) => predicate(broadcast)
+      );
+
+      return this;
+    }
+  }
+
+  private readonly SyncSubject _subject;
+  private readonly Passthrough _passthrough;
+  private readonly BoxlessQueue _boxlessQueue;
+
+  /// <summary>
+  /// <para>
+  /// Creates a new auto channel.
+  /// </para>
+  /// <para>
+  /// <inheritdoc cref="AutoChannel"/>
+  /// </para>
+  /// </summary>
+  public AutoChannel()
+  {
+    _subject = new SyncSubject(this);
+    _passthrough = new Passthrough(this);
+    _boxlessQueue = new BoxlessQueue();
+  }
+
+  /// <inheritdoc />
+  public Binding Bind() => new(_subject);
+
+  /// <inheritdoc />
+  public void ClearBindings() => _subject.ClearBindings();
+
+  /// <inheritdoc />
+  public void Dispose() => _subject.Dispose();
+
+  /// <summary>
+  /// <para>
+  /// Broadcasts the given value type to all subscribers.
+  /// </para>
+  /// </summary>
+  /// <remarks>
+  /// Always remember that pushing a struct as an interface or object will box
+  /// the value
+  /// </remarks>
+  /// <param name="value">Value to update with</param>
+  /// <typeparam name="T">Value Type</typeparam>
+  public void Send<T>(in T value) where T : struct
+  {
+    _boxlessQueue.Enqueue(value);
+    _subject.Perform(new PopOp());
+  }
+
+  private void Broadcast<T>(in T value) where T : struct =>
+    _subject.Broadcast(value); // invoke callbacks registered for this value
+
+  void IPerform<PopOp>.Perform(in PopOp op) =>
+    _boxlessQueue.Dequeue(_passthrough);
+
+  private readonly struct Passthrough(AutoChannel channel) : IBoxlessValueHandler
+  {
+    private AutoChannel Channel { get; } = channel;
+
+    public void HandleValue<TValue>(in TValue value) where TValue : struct =>
+      Channel.Broadcast(value);
+  }
+}


### PR DESCRIPTION
  - Add `AutoChannel` primitive which doesn't hold onto any values sent through it
  - Updated `AutoCache` with duplicate filtering for consecutive updates
  - Support custom equality comparers in `AutoCache` via `SetComparer<T>()` method
  - Unit tests added/updated
  - Updated README with `AutoChannel` usage examples, conditional callbacks, and clarification on `AutoCache` vs `AutoChannel` use cases
